### PR TITLE
Protocol: Fix decoding of remaining charge time

### DIFF
--- a/protocol/message.go
+++ b/protocol/message.go
@@ -457,7 +457,7 @@ func (r *RegisterChargeStatus) Decode(m *PhevMessage) {
 	r.Charging = m.Data[0] == 0x1
 	r.Remaining = 0
 	if m.Data[2] != 0xff {
-		r.Remaining = int((m.Data[2] << 8) | m.Data[1])
+		r.Remaining = int(m.Data[2])<<8 | int(m.Data[1])
 	}
 	r.raw = m.Data
 }


### PR DESCRIPTION
My previous change for this contained an error w/ respect to bitshifting the high byte, which did not work at all. Convert both bytes to `int` before shifting.